### PR TITLE
When the argument is a string, try to parse it

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,13 @@ const someFilePath = '...';
 
 async function main() {
     const fileContent = await readFile(someFilePath, {encoding: 'utf8'});
+    // Optional object, useful when you want to keep track of validation results
+    const meta = {
+        src: someFilePath
+    };
     // Here you should handle the error in case the file is not a valid JSON file
     try {
-        const parsedObject = JSON.parse(fileContent);
-        console.log(validate(parsedObject).ok); // true or false depending on the file...
+        console.log(validate(fileContent, meta).ok); // true or false depending on the file...
     }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import * as ajv from "ajv";
+
 /**
  * Metadata object interface.
  */

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,34 @@
-interface ValidationResult {
-	status: boolean;
-	errors: ajv.ErrorObject[];
-	ok: () => boolean;
-}
+/**
+ * Metadata object interface.
+ */
+interface ObjectSource {
+	/**
+	 * Optional source of the object being validated (best example would be a file path).
+	 */
+	src?: string;
+};
 
-export function validate(obj: object): ValidationResult;
+/**
+ * Validation results.
+ */
+interface ValidationResult {
+	/**
+	 * If true, the object is a valid Monika After Story piano song. False otherwise.
+	 */
+	ok: boolean;
+	/**
+	 * Array of errors caught by the validator. If ok === true than this is an empty array.
+	 */
+	errors: ajv.ErrorObject[];
+	/**
+	 * Metadata object.
+	 */
+	meta: ObjectSource;
+};
+
+/**
+ * Perform JSON schema validation to the specified object.
+ * @param obj Required object to check. If of type string, JSON.parse will be called.
+ * @param meta Optional object, useful for "signing" the particular validation with an id.
+ */
+export default function validate(obj: object|string, meta?: ObjectSource): ValidationResult;

--- a/index.js
+++ b/index.js
@@ -9,14 +9,28 @@ const ajv = new Ajv({
 const rawValidate = ajv.compile(jsonSchema);
 
 class ValidationResult {
-	constructor(status, errors) {
+	constructor(meta, status, errors) {
+		this.meta = meta;
 		this.ok = status;
 		this.errors = errors;
 	}
 }
 
-function validate(obj) {
-	return new ValidationResult(rawValidate(obj), rawValidate.errors);
+function validate(obj, meta = {src: undefined}) {
+	if (typeof obj === 'string') {
+		try {
+			const parsed = JSON.parse(obj);
+			return new ValidationResult(meta, rawValidate(parsed), rawValidate.errors);
+		} catch (error) {
+			// TODO
+			// File is not a valid JSON:
+			// last chance is to try to guess if it's a path and then try to work with that
+
+			// TODO: use something to give the user/client a more accessible error
+			return new ValidationResult(meta, false, ['Specified argument was not a valid JSON literal']);
+		}
+	}
+	return new ValidationResult(meta, rawValidate(obj), rawValidate.errors);
 }
 
 module.exports = validate;


### PR DESCRIPTION
Related to #10 

If the argument is a string, try to `JSON.parse` it.