### PR TITLE
Add prettify API

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -41,7 +41,13 @@ export interface ValidationResult {
 	/**
 	 * Metadata object.
 	 */
-	meta: ObjectSource
+	meta: ObjectSource,
+	/**
+	 * Create a readable message from this object.
+	 *
+	 * @param {boolean} includeMeta Include the ObjectSource in the validation message.
+	 */
+	prettify: (includeMeta?: boolean) => string
 }
 
 /**
@@ -62,3 +68,10 @@ export default function validate(obj: string|object, meta?: ObjectSource): Valid
  * all(...);
  */
 export function all(obj: string[]|ValidationItem[]|object[]): ValidationResult[];
+
+/**
+ * Create a readable message from the specified object.
+ *
+ * @param result
+ */
+export function prettify(result: ValidationResult|ValidationResult[]): string;

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const {EOL} = require('os');
+
 const Ajv = require('ajv');
 
 const jsonSchema = require('./schema/piano.schema.json');
@@ -14,6 +16,40 @@ class ValidationResult {
 		this.ok = status;
 		this.errors = errors;
 	}
+
+	prettify(includeMeta = false) {
+		let prettified = '';
+		if (includeMeta) {
+			prettified += `${this.meta.src} - `;
+		}
+		if (this.ok) {
+			prettified += 'This file is a valid Monika After Story piano song!';
+		} else {
+			prettified += 'This file is NOT a valid Monika After Story piano song.';
+		}
+		return prettified;
+	}
+}
+
+function prettify(result) {
+	if (Array.isArray(result)) {
+		// Find at least one object in the array that is not ValidationResult
+		const notValidationResult = result.find(r => !(r instanceof ValidationResult));
+		if (notValidationResult) {
+			throw new TypeError('The results passed in contained at least an object not of type ValidationResult');
+		}
+		// Check if all ValidationResults are valid
+		const allValid = result.find(r => r.ok === false) === undefined;
+		if (allValid) {
+			return 'All files are valid Monika After Story piano songs!';
+		}
+		const introMsg = `Some songs are NOT valid Monika After Story piano songs.${EOL}Details:${EOL}`;
+		return introMsg + result.reduce((prev, curr) => prev.concat(`${EOL}${curr.prettify(true)}`), '');
+	}
+	if (!(result instanceof ValidationResult)) {
+		throw new TypeError('Cannot prettify anything other than a ValidationResult object');
+	}
+	return result.prettify();
 }
 
 function validateAll(obj) {
@@ -49,3 +85,4 @@ function validate(obj, meta = {src: undefined}) {
 module.exports = validate;
 module.exports.default = validate;
 module.exports.all = validateAll;
+module.exports.prettify = prettify;

--- a/test.js
+++ b/test.js
@@ -100,14 +100,14 @@ describe('Core library testing', () => {
 			expect(result.ok).toStrictEqual(false);
 			expect(result.errors).toHaveLength(1);
 			// Match the error message
-			expect(result.errors[0]).toMatch(/not.*valid json literal/gmi);
+			expect(result.errors[0]).toMatch(/not.*valid json literal/i);
 		});
 	});
 
 	describe('when using the \'all\' API', () => {
 		it('should signal the user if the passed argument is not an array', () => {
-			expect(() => validate.all({})).toThrowError(/.*received.*object$/gmi);
-			expect(() => validate.all('a')).toThrowError(/.*received.*string$/gmi);
+			expect(() => validate.all({})).toThrowError(/.*received.*object$/mi);
+			expect(() => validate.all('a')).toThrowError(/.*received.*string$/mi);
 		});
 
 		it('should validate all of the arguments (source unknwown)', () => {
@@ -157,19 +157,19 @@ describe('Core library testing', () => {
 		it('should be able to create a readable message from the ValidationResult (with valid input and with source info)', () => {
 			const example = new MinimalExample();
 			const prettyMsg = validate(example).prettify(true);
-			expect(prettyMsg).toMatch(/(.*)( - )(.*valid.*song)/gmi);
+			expect(prettyMsg).toMatch(/(.*)( - )(.*valid.*song)/i);
 		});
 
 		it('should be able to create a readable message from the ValidationResult (with valid input and without source info)', () => {
 			const example = new MinimalExample();
 			const prettyMsg = validate(example).prettify();
-			expect(prettyMsg).toMatch(/.*valid.*song/gmi);
+			expect(prettyMsg).toMatch(/.*valid.*song/i);
 		});
 
 		it('should be able to create a readable message from the ValidationResult (with invalid input)', () => {
 			const example = new MinimalExample({enableName: false});
 			const prettyMsg = validate(example).prettify();
-			expect(prettyMsg).toMatch(/.*not.*valid.*song/gmi);
+			expect(prettyMsg).toMatch(/.*not.*valid.*song/i);
 		});
 
 		it('should throw a \'TypeError\' when at least one of the input is not a ValidationResult instance', () => {
@@ -193,7 +193,7 @@ describe('Core library testing', () => {
 				}
 			];
 			const results = validate.all(exampleData);
-			expect(validate.prettify(results)).toMatch(/.*all.*valid.*songs/gmi);
+			expect(validate.prettify(results)).toMatch(/.*all.*valid.*songs/i);
 		});
 
 		it('should create a multiline message from various ValidationResults when at least one input is not valid', () => {
@@ -209,7 +209,8 @@ describe('Core library testing', () => {
 				}
 			];
 			const results = validate.all(exampleData);
-			expect(validate.prettify(results)).toMatch(/.*some.*not valid.*songs.*details/gmi);
+			// The s regex flag allows '.' to match newlines too
+			expect(validate.prettify(results)).toMatch(/.*some.*not valid.*songs.*details:.*/is);
 		});
 	});
 });


### PR DESCRIPTION
Users should use this API when the details of the errors are not needed.
For this first implementation, return unlocalized (English) strings.
In the future, I may implement something for localizing these messages.