### PR TITLE
Removed prettify API. 👀

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,10 +31,6 @@ export interface ValidationItem {
  */
 export interface ValidationResult {
 	/**
-	 * If true, the object is a valid Monika After Story piano song. False otherwise.
-	 */
-	ok: boolean,
-	/**
 	 * Array of errors caught by the validator. If ok === true than this is an empty array.
 	 */
 	errors: ajv.ErrorObject[],
@@ -43,11 +39,41 @@ export interface ValidationResult {
 	 */
 	meta: ObjectSource,
 	/**
-	 * Create a readable message from this object.
-	 *
-	 * @param {boolean} includeMeta Include the ObjectSource in the validation message.
+	 * If true, the object is a valid Monika After Story piano song. False otherwise.
 	 */
-	prettify: (includeMeta?: boolean) => string
+	ok: boolean,
+	/**
+	 * Brief description about the result of this validation.
+	 */
+	summary: string
+}
+
+/**
+ * Container of multiple `ValidationResult`s.
+ * This kind of object includes an ok flag (true means all the ValidationResults are valid Monika After Story piano songs),
+ * a results array containing the `ValidationResult` instances.
+ */
+export interface ValidationResultsContainer {
+	/**
+	 * If true, all the ValidationResults are valid Monika After Story piano songs. False otherwise.
+	 */
+	ok: boolean,
+	/**
+	 * Array of all the ValidationResult objects.
+	 */
+	results: ValidationResult[],
+	/**
+	 * Brief sentence describing the aggregated validation state.
+	 */
+	summary: string,
+	/**
+	 * Array of only valid ValidationResult objects.
+	 */
+	validResults: ValidationResult[],
+	/**
+	 * Array of only invalid ValidationResult objects.
+	 */
+	invalidResults: ValidationResult[]
 }
 
 /**
@@ -67,11 +93,4 @@ export default function validate(obj: string|object, meta?: ObjectSource): Valid
  *
  * all(...);
  */
-export function all(obj: string[]|ValidationItem[]|object[]): ValidationResult[];
-
-/**
- * Create a readable message from the specified object.
- *
- * @param result
- */
-export function prettify(result: ValidationResult|ValidationResult[]): string;
+export function all(obj: string[]|ValidationItem[]|object[]): ValidationResultsContainer;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-const {EOL} = require('os');
-
 const Ajv = require('ajv');
 
 const jsonSchema = require('./schema/piano.schema.json');
@@ -11,78 +9,57 @@ const ajv = new Ajv({
 const rawValidate = ajv.compile(jsonSchema);
 
 class ValidationResult {
-	constructor(meta, status, errors) {
+	constructor(status, errors, meta = {src: undefined}) {
 		this.meta = meta;
 		this.ok = status;
 		this.errors = errors;
-	}
 
-	prettify(includeMeta = false) {
-		let prettified = '';
-		if (includeMeta) {
-			prettified += `${this.meta.src} - `;
-		}
-		if (this.ok) {
-			prettified += 'This file is a valid Monika After Story piano song!';
-		} else {
-			prettified += 'This file is NOT a valid Monika After Story piano song.';
-		}
-		return prettified;
+		this.summary = status === true ? 'This file is a valid Monika After Story piano song.' : 'This file is NOT a valid Monika After Story piano song.';
 	}
 }
 
-function prettify(result) {
-	if (Array.isArray(result)) {
-		// Find at least one object in the array that is not ValidationResult
-		const notValidationResult = result.find(r => !(r instanceof ValidationResult));
-		if (notValidationResult) {
-			throw new TypeError('The results passed in contained at least an object not of type ValidationResult');
-		}
-		// Check if all ValidationResults are valid
-		const allValid = result.find(r => r.ok === false) === undefined;
-		if (allValid) {
-			return 'All files are valid Monika After Story piano songs!';
-		}
-		const introMsg = `Some songs are NOT valid Monika After Story piano songs.${EOL}Details:${EOL}`;
-		return introMsg + result.reduce((prev, curr) => prev.concat(`${EOL}${curr.prettify(true)}`), '');
+class ValidationResultsContainer {
+	constructor(results) {
+		this.results = results;
+		this.validResults = results.filter(result => result.ok === true);
+		this.invalidResults = results.filter(result => result.ok === false);
+		const allValid = this.validResults.length === results.length && this.invalidResults.length === 0;
+		this.ok = allValid;
+		this.summary = allValid ? 'All files are valid Monika After Story piano songs!' : 'Some files are NOT valid Monika After Story piano songs.';
 	}
-	if (!(result instanceof ValidationResult)) {
-		throw new TypeError('Cannot prettify anything other than a ValidationResult object');
-	}
-	return result.prettify();
 }
 
-function validateAll(obj) {
-	if (Array.isArray(obj)) {
-		return obj.map(validationItem => {
+function validateAll(validationItems) {
+	if (Array.isArray(validationItems)) {
+		const results = validationItems.map(validationItem => {
 			if (validationItem.content && validationItem.meta) {
 				return validate(validationItem.content, validationItem.meta);
 			}
 			return validate(validationItem);
 		});
+		return new ValidationResultsContainer(results);
 	}
 	// TODO: find a way to communicate the wrong API
-	throw new Error(`The 'all' function expects an argument of type array, instead it received a ${typeof obj}`);
+	throw new Error(`The 'all' function expects an argument of type array, instead it received a ${typeof validationItems}`);
 }
 
-function validate(obj, meta = {src: undefined}) {
+function validate(obj, meta) {
 	if (typeof obj === 'string') {
 		try {
 			const parsed = JSON.parse(obj);
-			return new ValidationResult(meta, rawValidate(parsed), rawValidate.errors);
+			return new ValidationResult(rawValidate(parsed), rawValidate.errors, meta);
 		} catch (error) {
 			// TODO
 			// File is not a valid JSON:
 			// last chance is to try to guess if it's a path and then try to work with that
 
 			// TODO: use something to give the user/client a more accessible error
-			return new ValidationResult(meta, false, ['Specified argument was not a valid JSON literal']);
+			return new ValidationResult(false, ['Specified argument was not a valid JSON literal'], meta);
 		}
 	}
-	return new ValidationResult(meta, rawValidate(obj), rawValidate.errors);
+	return new ValidationResult(rawValidate(obj), rawValidate.errors, meta);
 }
 
 module.exports = validate;
 module.exports.default = validate;
 module.exports.all = validateAll;
-module.exports.prettify = prettify;

--- a/index.js
+++ b/index.js
@@ -25,7 +25,16 @@ class ValidationResultsContainer {
 		this.invalidResults = results.filter(result => result.ok === false);
 		const allValid = this.validResults.length === results.length && this.invalidResults.length === 0;
 		this.ok = allValid;
-		this.summary = allValid ? 'All files are valid Monika After Story piano songs!' : 'Some files are NOT valid Monika After Story piano songs.';
+		const allInvalid = this.validResults.length === 0 && this.invalidResults.length === results.length;
+		let summary;
+		if (allValid) {
+			summary = 'All files are valid Monika After Story piano songs.';
+		} else if (allInvalid) {
+			summary = 'All files are NOT valid Monika After Story piano songs.';
+		} else {
+			summary = 'Some files are NOT valid Monika After Story piano songs.';
+		}
+		this.summary = summary;
 	}
 }
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd-check';
-import validate, {ValidationResult, all} from '.';
+import validate, {ValidationResult, all, ValidationResultsContainer} from '.';
 
 expectType<ValidationResult>(validate('test'));
 
@@ -7,4 +7,4 @@ expectType<ValidationResult>(validate('test', {
 	src: 'test'
 }));
 
-expectType<ValidationResult[]>(all(['test']));
+expectType<ValidationResultsContainer>(all(['test']));

--- a/test.js
+++ b/test.js
@@ -119,7 +119,7 @@ describe('Core library testing', () => {
 			];
 			const results = validate.all(exampleData);
 			expect(results.ok).toStrictEqual(true);
-			expect(results.summary).toStrictEqual('All files are valid Monika After Story piano songs!');
+			expect(results.summary).toStrictEqual('All files are valid Monika After Story piano songs.');
 			expect(results.results).toHaveLength(3);
 			expect(results.validResults).toHaveLength(3);
 			expect(results.invalidResults).toHaveLength(0);
@@ -137,6 +137,19 @@ describe('Core library testing', () => {
 			expect(results.results).toHaveLength(3);
 			expect(results.validResults).toHaveLength(2);
 			expect(results.invalidResults).toHaveLength(1);
+		});
+
+		it('should have ok = false and appropriate summary when all arguments are invalid', () => {
+			const exampleData = [
+				new MinimalExample({enableName: false}),
+				new MinimalExample({enablePnmList: false})
+			];
+			const results = validate.all(exampleData);
+			expect(results.ok).toStrictEqual(false);
+			expect(results.summary).toStrictEqual('All files are NOT valid Monika After Story piano songs.');
+			expect(results.results).toHaveLength(2);
+			expect(results.validResults).toHaveLength(0);
+			expect(results.invalidResults).toHaveLength(2);
 		});
 	});
 });


### PR DESCRIPTION
"API for validation on multiple objects should return data in a more structured way."

`validation.all` now returns an aggregated view on the validation results, giving more power to the library users.
Both the aggregated view and the single validation result now provide a new "summary" property that describes the validation status with a string (English).

```js
// ValidationResultsContainer API Example
...
const results = validate.all(...);

// All raw ValidationResult instances 
console.log(results.results);

// All valid or invalid ValidationResult instances
console.log(results.validResults);
console.log(results.invalidResults);

// Global validation status: if true all objects passed are valid MAS Piano songs
console.log(results.ok);

// Brief validation description ("all/some/none are valid MAS piano songs")
console.log(results.summary);
```

Fixes #16.